### PR TITLE
Add Troubleshooting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,6 @@ If not, send private message on XDA to [me](https://forum.xda-developers.com/m/v
 2. Flash in Magisk
 3. Reboot & enjoy 
 
-## Troubleshooting
-Try one or more of the following methods:
-- Toggle VoLTE/VoWiFi/Airplane mode
-- Reset APN settings to default
-- Remove unnecessary MBN files(e.g. those for carriers in another continent) in the module, remove the corresponding lines in oem_sw.txt, then repack the ZIP file and reinstall
-
-
 ## Features
 - Enables VoLTE
 - Enables VoWiFi
@@ -25,6 +18,12 @@ Try one or more of the following methods:
 
 ## Verified
 - Pixel 2 - LineageOS 20 - - Orange Poland - VoLTE & VoWiFi
+
+## Troubleshooting
+Try one or more of the following methods:
+- Toggle VoLTE/VoWiFi/Airplane mode
+- Reset APN settings to default
+- Remove unnecessary MBN files(e.g. those for carriers in another continent) in the module, remove the corresponding lines in oem_sw.txt, then repack the ZIP file and reinstall
 
 # Credits
 - Big thanks to [IonutGherman](https://forum.xda-developers.com/m/ionutgherman.6250062/) from XDA for providing intial MBNs from crDroid.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ If not, send private message on XDA to [me](https://forum.xda-developers.com/m/v
 2. Flash in Magisk
 3. Reboot & enjoy 
 
+## Troubleshooting
+Try one or more of the following methods:
+- Toggle VoLTE/VoWiFi/Airplane mode
+- Reset APN settings to default
+- Remove unnecessary MBN files(e.g. those for carriers in another continent) in the module, remove the corresponding lines in oem_sw.txt, then repack the ZIP file and reinstall
+
+
 ## Features
 - Enables VoLTE
 - Enables VoWiFi


### PR DESCRIPTION
I was trying to make VoLTE and VoWiFi work on my Pixel 2 XL in the past week.
I found this module containing the MBN for my carrier and tried it but and it didn't work.
Then I also tried porting MBN files for my carrier from other Snapdragon 835 phones to this module, with or without modifying them, but none of them worked.

I was exhausted and decided to give it one last try.
I removed the unnecessary MBNs in the module.
I also reset the APN settings although I had never changed them.

IT WORKED!